### PR TITLE
WayPoints are not added correctly, add optimizeWaypoints option

### DIFF
--- a/lib/flutter_polyline_points.dart
+++ b/lib/flutter_polyline_points.dart
@@ -21,15 +21,13 @@ class PolylinePoints {
   /// which can be used to draw polyline between this two positions
   ///
   Future<PolylineResult> getRouteBetweenCoordinates(
-    String googleApiKey,
-    PointLatLng origin,
-    PointLatLng destination, {
-    TravelMode travelMode = TravelMode.driving,
-    List<PolylineWayPoint> wayPoints = const [],
-    bool avoidHighways = false,
-    bool avoidTolls = false,
-    bool avoidFerries = true,
-  }) async {
+      String googleApiKey, PointLatLng origin, PointLatLng destination,
+      {TravelMode travelMode = TravelMode.driving,
+      List<PolylineWayPoint> wayPoints = const [],
+      bool avoidHighways = false,
+      bool avoidTolls = false,
+      bool avoidFerries = true,
+      bool optimizeWaypoints = false}) async {
     return await util.getRouteBetweenCoordinates(
         googleApiKey,
         origin,
@@ -38,7 +36,8 @@ class PolylinePoints {
         wayPoints,
         avoidHighways,
         avoidTolls,
-        avoidFerries);
+        avoidFerries,
+        optimizeWaypoints);
   }
 
   /// Decode and encoded google polyline

--- a/lib/src/network_util.dart
+++ b/lib/src/network_util.dart
@@ -13,15 +13,15 @@ class NetworkUtil {
   ///Get the encoded string from google directions api
   ///
   Future<PolylineResult> getRouteBetweenCoordinates(
-    String googleApiKey,
-    PointLatLng origin,
-    PointLatLng destination,
-    TravelMode travelMode,
-    List<PolylineWayPoint> wayPoints,
-    bool avoidHighways,
-    bool avoidTolls,
-    bool avoidFerries,
-  ) async {
+      String googleApiKey,
+      PointLatLng origin,
+      PointLatLng destination,
+      TravelMode travelMode,
+      List<PolylineWayPoint> wayPoints,
+      bool avoidHighways,
+      bool avoidTolls,
+      bool avoidFerries,
+      bool optimizeWaypoints) async {
     String mode = travelMode.toString().replaceAll('TravelMode.', '');
     PolylineResult result = PolylineResult();
     var params = {
@@ -34,11 +34,15 @@ class NetworkUtil {
       "key": googleApiKey
     };
     if (wayPoints.isNotEmpty) {
-      params.addAll({
-        "waypoints": json.encode(List.from(wayPoints.map((e) => e.toMap())))
-      });
+      List<String> wayPointsArray = wayPoints.map((point) => point.toString());
+      String wayPointsString = wayPointsArray.join('|');
+      if (optimizeWaypoints) {
+        wayPointsString = 'optimize:true|$wayPointsString';
+      }
+      params.addAll({"waypoints": wayPointsString});
     }
-    Uri uri = Uri.https("maps.googleapis.com", "maps/api/directions/json", params);
+    Uri uri =
+        Uri.https("maps.googleapis.com", "maps/api/directions/json", params);
 
     String url = uri.toString();
     print('GOOGLE MAPS URL: ' + url);

--- a/lib/src/utils/polyline_waypoint.dart
+++ b/lib/src/utils/polyline_waypoint.dart
@@ -2,11 +2,10 @@ import 'package:flutter/material.dart';
 
 /// description:
 /// project: flutter_polyline_points
-/// @package: 
+/// @package:
 /// @author: dammyololade
 /// created on: 12/05/2020
 class PolylineWayPoint {
-
   /// the location of the waypoint,
   /// You can specify waypoints using the following values:
   /// --- Latitude/longitude coordinates (lat/lng): an explicit value pair. (-34.92788%2C138.60008 comma, no space),
@@ -20,16 +19,14 @@ class PolylineWayPoint {
   /// which has the effect of splitting the route into two routes
   bool stopOver;
 
-
   PolylineWayPoint({@required this.location, this.stopOver = true});
-
-  Map<String, dynamic> toMap() => {
-    "location": location,
-    "stopover": stopOver
-  };
 
   @override
   String toString() {
-    return "location=$location,stopover=$stopOver";
+    if (stopOver) {
+      return location;
+    } else {
+      return "via:$location";
+    }
   }
 }


### PR DESCRIPTION
According to google dev doc, the wayPoints are added as a string. The points are separated by "|". If the points is not stopped over, add prefix "via:" on the point. If the user needs optimize the waypoints, add prefix "optimize:true|" in front of entire waypoints. (It's my first time of doing PR on public repo. I'm  kind of excited)