### PR TITLE
Add to support restricted API keys

### DIFF
--- a/lib/src/network_util.dart
+++ b/lib/src/network_util.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:google_api_headers/google_api_headers.dart';
+
 import '../src/utils/polyline_waypoint.dart';
 import '../src/utils/request_enums.dart';
 import '../src/PointLatLng.dart';
@@ -46,8 +48,9 @@ class NetworkUtil {
         Uri.https("maps.googleapis.com", "maps/api/directions/json", params);
 
     String url = uri.toString();
+    final headers = await GoogleApiHeaders().getHeaders();
     // print('GOOGLE MAPS URL: ' + url);
-    var response = await http.get(url);
+    var response = await http.get(url, headers: headers);
     if (response?.statusCode == 200) {
       var parsedJson = json.decode(response.body);
       result.status = parsedJson["status"];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  google_api_headers: ">=0.1.0 <1.0.0"
   http: ^0.12.0+2
 
 dev_dependencies:


### PR DESCRIPTION
- Add [`google_api_headers`](https://pub.dev/packages/google_api_headers) as a dependency which provides the required headers for making Google API calls with app restricted keys
- Add to support calling Google APIs when the API key is restricted to iOS or Android apps
- Related issues: #23 