### PR TITLE
Fix for intermediates locations

### DIFF
--- a/lib/src/routes_api/routes_request.dart
+++ b/lib/src/routes_api/routes_request.dart
@@ -98,7 +98,7 @@ class RoutesApiRequest {
     if (intermediates != null && intermediates!.isNotEmpty) {
       json['intermediates'] = intermediates!
           .map((waypoint) => {
-                'location': _parseLocationString(waypoint.location),
+                ..._parseLocationString(waypoint.location),
                 'via': !waypoint.stopOver,
               })
           .toList();


### PR DESCRIPTION
Instead of creating 
`
{
  "location" :
    "location" : { ... }
    ...
`
changes to just one location as the documentation requires 