### PR TITLE
Add unspecified RoutingPreference to routes API

### DIFF
--- a/lib/src/routes_api/enums/routing_preference.dart
+++ b/lib/src/routes_api/enums/routing_preference.dart
@@ -1,6 +1,9 @@
 /// Routing preferences for the Google Routes API
 /// Determines how routes are optimized
 enum RoutingPreference {
+  /// Unspecified, defaults to [trafficUnaware].
+  unspecified('ROUTING_PREFERENCE_UNSPECIFIED'),
+
   /// Prioritize routes with the shortest travel time
   trafficUnaware('TRAFFIC_UNAWARE'),
   
@@ -28,6 +31,8 @@ enum RoutingPreference {
   /// Get a human-readable description of the routing preference
   String get description {
     switch (this) {
+      case RoutingPreference.unspecified:
+        return 'Unspecified preference. Defaults to traffic unaware';
       case RoutingPreference.trafficUnaware:
         return 'Fastest route without considering traffic';
       case RoutingPreference.trafficAware:

--- a/lib/src/routes_api/routes_request.dart
+++ b/lib/src/routes_api/routes_request.dart
@@ -80,7 +80,12 @@ class RoutesApiRequest {
     this.extraComputations,
     this.responseFieldMask,
     this.customBodyParameters,
-  });
+  }) : assert(
+          (travelMode != TravelMode.bicycling &&
+                  travelMode != TravelMode.walking) ||
+              (routingPreference == RoutingPreference.unspecified),
+          'Invalid request: Bicycling and walking travel modes must use RoutingPreference.unspecified.',
+        );
 
   /// Convert to JSON for API request
   Map<String, dynamic> toJson() {


### PR DESCRIPTION
# RoutingPreference error

## The error

When requesting routes with `RouteTravelMode.walking` or
`RouteTravelMode.bicycling`, the following error is returned by the Routes API.

```
Routes API error: 400 - Routing preference cannot be set for WALK or BICYCLE routing mode.
```

## The fix

Adds the RoutingPreference ROUTING_PREFERENCE_UNSPECIFIED.

RouteTravelMode's WALK and BICYCLE can only be paired with the
unspecified preference, so this commit also adds an assert to prevent
building invalid requests.
